### PR TITLE
Агент поиска рекомендаций + фиксы БЗ

### DIFF
--- a/books_agents/search_agents/agent_of_finding_similar_books/agent_of_finding_similar_books.scsi
+++ b/books_agents/search_agents/agent_of_finding_similar_books/agent_of_finding_similar_books.scsi
@@ -67,10 +67,31 @@ scp_program -> agent_of_finding_similar_books
 
 			-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _answer;;
 
-			=> nrel_goto: .agent_of_finding_similar_books_operator_call_proc;;
+			=> nrel_goto: .agent_of_finding_similar_books_operator_gen_node;;
 		*);;
 
-	-> .agent_of_finding_similar_books_operator_call_proc
+        -> .agent_of_finding_similar_books_operator_gen_node
+        (*
+            <- genEl;;
+
+            -> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _similar_books;;
+
+            => nrel_goto: .agent_of_finding_similar_books_operator_find_author;;
+        *);;
+       
+        -> .agent_of_finding_similar_books_operator_find_author
+        (*
+            <- searchElStr5;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _book;;
+            -> rrel_2: rrel_assign: rrel_common: rrel_scp_var: _arc;;
+            -> rrel_3: rrel_assign: rrel_scp_var: _book_author;;
+            -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _pos_arc;;
+            -> rrel_5: rrel_fixed:  rrel_scp_const: nrel_author;;
+
+            => nrel_goto: .agent_of_finding_similar_books_operator_call_proc;;
+        *);;
+	    -> .agent_of_finding_similar_books_operator_call_proc
 		(*
 			<- call;;
 
@@ -78,7 +99,8 @@ scp_program -> agent_of_finding_similar_books
 			-> rrel_2: rrel_fixed: rrel_scp_const: ...
 			(*
 					-> rrel_1: rrel_fixed: rrel_scp_var: _book;;
-					-> rrel_2: rrel_assign: rrel_scp_var: _similar_books;;
+					-> rrel_2: rrel_fixed: rrel_scp_var: _book_author;;
+					-> rrel_3: rrel_fixed: rrel_scp_var: _similar_books;;
 			*);;
 			-> rrel_3: rrel_assign: rrel_scp_var: _agent_of_finding_similar_books_descriptor;;
 

--- a/books_agents/search_agents/agent_of_finding_similar_books/proc_find_books_of_author.scs
+++ b/books_agents/search_agents/agent_of_finding_similar_books/proc_find_books_of_author.scs
@@ -3,7 +3,7 @@ scp_program -> proc_find_books_of_author
     -> rrel_params: ...
     (*
         -> rrel_1: rrel_in: _author;;
-        -> rrel_2: rrel_out: _author_books;;
+        -> rrel_2: rrel_in: _author_books;;
     *);;
 
     -> rrel_operators: ...
@@ -15,21 +15,11 @@ scp_program -> proc_find_books_of_author
 
             -> rrel_1: rrel_scp_const: [Начало. Процедура нахождения книг автора];;
 
-            => nrel_goto: .proc_find_books_of_author_operator_find_book_author_gen;;
-        *);;
-
-	-> .proc_find_books_of_author_operator_find_book_author_gen
-        (*
-            <- genEl;;
-
-           -> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _author_books;;
-
             => nrel_goto: .proc_find_books_of_author_operator_find_author_all_books;;
         *);;
 
 
         // Поиск книг автора
-
         -> .proc_find_books_of_author_operator_find_author_all_books
         (*
             <- searchSetStr5;;
@@ -40,33 +30,121 @@ scp_program -> proc_find_books_of_author
             -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _pos_arc;;
             -> rrel_5: rrel_fixed:  rrel_scp_const: nrel_author;;
 
-            -> rrel_set_1: rrel_fixed: rrel_scp_var: _author_books;;
+            -> rrel_set_1: rrel_assign: rrel_scp_var: _temp_author_books_set;;
 
-            => nrel_goto: .proc_find_books_of_author_operator_check_books;;
-        *);;
-
-        -> .proc_find_books_of_author_operator_check_books
-        (*
-            <- searchElStr3;;
-
-            -> rrel_1: rrel_fixed: rrel_scp_var: _author_books;;
-            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _temp_book_arc;;
-            -> rrel_3: rrel_assign: rrel_scp_var: _book;;
-
-            => nrel_then: .proc_find_books_of_author_operator_books_found;;
-
+            => nrel_then: .proc_find_books_of_author_operator_loop_books;;
             => nrel_else: .proc_find_books_of_author_operator_books_not_found;;
         *);;
 
-	-> .proc_find_books_of_author_operator_books_found
+        -> .proc_find_books_of_author_operator_loop_books
+        (*
+            <- searchElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _temp_author_books_set;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _temp_book_arc;;
+            -> rrel_3: rrel_assign: rrel_scp_var: _book;;
+
+            => nrel_then: .proc_find_books_of_author_operator_erase_book_from_temp;;
+
+            => nrel_else: .proc_find_books_of_author_operator_books_found;;
+        *);;
+
+         -> .proc_find_books_of_author_operator_erase_book_from_temp
+        (*
+            <- eraseEl;;
+
+            -> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _temp_book_arc;;
+
+            => nrel_goto: .proc_find_books_of_author_operator_check_exist;;
+        *);;
+
+
+        -> .proc_find_books_of_author_operator_check_exist
+        (*
+            <- searchSetStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _author_books;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _temp_author_book_arc;;
+            -> rrel_3: rrel_assign: rrel_scp_var: _curr_author_book;;
+
+            -> rrel_set_3: rrel_assign: rrel_scp_var: _temp_author_books;;
+
+			=> nrel_then: .proc_find_books_of_author_operator_check_exist_2;;
+			=> nrel_else: .proc_find_books_of_author_operator_add_to_author_books_first_book;;
+        *);;
+
+         -> .proc_find_books_of_author_operator_check_exist_2
+        (*
+            <- searchElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _temp_author_books;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _temp_curr_book_arc_in_author_books;;
+            -> rrel_3: rrel_assign: rrel_scp_var: _curr_temp_author_book;;
+
+			=> nrel_then: .proc_find_books_of_author_operator_check_exist_3;;
+			=> nrel_else: .proc_find_books_of_author_operator_add_to_author_books;;
+        *);;
+
+         -> .proc_find_books_of_author_operator_check_exist_3
+        (*
+            <- eraseEl;;
+
+            -> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _temp_curr_book_arc_in_author_books;;
+
+            => nrel_goto: .proc_find_books_of_author_operator_check_exist_4;;
+        *);;
+
+        -> .proc_find_books_of_author_operator_check_exist_4
+        (*
+            <- ifCoin;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _curr_temp_author_book;;
+            -> rrel_2: rrel_fixed: rrel_scp_var: _book;;
+
+            => nrel_then: .proc_find_books_of_author_operator_loop_books;;
+            => nrel_else: .proc_find_books_of_author_operator_check_exist_2;;
+         *);;
+
+
+        -> .proc_find_books_of_author_operator_add_to_author_books_first_book
+        (*
+            <- genElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _author_books;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _temp_book_arc;;
+            -> rrel_3: rrel_fixed: rrel_scp_var: _book;;
+
+	        => nrel_goto: .proc_find_books_of_author_operator_loop_books;;
+        *);;
+
+        -> .proc_find_books_of_author_operator_add_to_author_books
+        (*
+            <- genElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _author_books;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _temp_book_arc;;
+            -> rrel_3: rrel_fixed: rrel_scp_var: _book;;
+
+	        => nrel_goto: .proc_find_books_of_author_operator_loop_books;;
+        *);;
+
+        -> .proc_find_books_of_author_operator_books_found
         (*
             <- printNl;;
 
             -> rrel_1: rrel_scp_const: [Книги автора найдены!];;
+            => nrel_goto: .proc_find_books_of_author_operator_books_print_result;;
+        *);;
+
+        -> .proc_find_books_of_author_operator_books_print_result
+        (*
+            <- printEl;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _author_books;;
             => nrel_goto: .proc_find_books_of_author_operator_print_end;;
         *);;
 
-   -> .proc_find_books_of_author_operator_books_not_found
+        -> .proc_find_books_of_author_operator_books_not_found
         (*
             <- printNl;;
 
@@ -75,8 +153,7 @@ scp_program -> proc_find_books_of_author
             => nrel_goto: .proc_find_books_of_author_operator_print_end;;
         *);;
 
-
-	-> .proc_find_books_of_author_operator_print_end
+	    -> .proc_find_books_of_author_operator_print_end
         (*
             <- printNl;;
 

--- a/books_agents/search_agents/agent_of_finding_similar_books/proc_find_similar_books.scs
+++ b/books_agents/search_agents/agent_of_finding_similar_books/proc_find_similar_books.scs
@@ -3,7 +3,8 @@ scp_program -> proc_find_similar_books
     -> rrel_params: ...
     (*
         -> rrel_1: rrel_in: _book;;
-        -> rrel_2: rrel_out: _similar_books;;
+        -> rrel_2: rrel_in: _book_author;;
+        -> rrel_3: rrel_in: _similar_books;;
     *);;
 
     -> rrel_operators: ...
@@ -19,36 +20,13 @@ scp_program -> proc_find_similar_books
         *);;
 
 
-        // Поиск автора
-	-> .proc_find_similar_books_operator_generate_similar_books_set
-        (*
-            <- genEl;;
-
-            -> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _similar_books;;
-
-            => nrel_goto: .proc_find_similar_books_operator_find_book_author0;;
-        *);;
-        -> .proc_find_similar_books_operator_find_book_author0
-        (*
-            <- genEl;;
-
-            -> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _book_author;;
-
-            => nrel_goto: .proc_find_similar_books_operator_find_book_author;;
-        *);;
-
-
-        // Поиск автора
+        // Проверка наличия автора
 
     	-> .proc_find_similar_books_operator_find_book_author
         (*
-            <- searchElStr5;;
+            <- ifVarAssign;;
 
-            -> rrel_1: rrel_fixed: rrel_scp_var: _book;;
-            -> rrel_2: rrel_assign: rrel_common: rrel_scp_var: _arc;;
-            -> rrel_3: rrel_assign: rrel_scp_var: _book_author;;
-            -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _pos_arc;;
-            -> rrel_5: rrel_fixed:  rrel_scp_const: nrel_author;;
+            -> rrel_1: rrel_fixed: rrel_scp_var: _book_author;;
 
             => nrel_then: .proc_find_similar_books_operator_find_author_all_books;;
             => nrel_else: .proc_find_similar_books_operator_print_end;;
@@ -62,7 +40,7 @@ scp_program -> proc_find_similar_books
 			-> rrel_2: rrel_fixed: rrel_scp_const: ...
 			(*
 					-> rrel_1: rrel_fixed: rrel_scp_var: _book_author;;
-					-> rrel_2: rrel_assign: rrel_scp_var: _similar_books;;
+					-> rrel_2: rrel_fixed: rrel_scp_var: _similar_books;;
 			*);;
 			-> rrel_3: rrel_assign: rrel_scp_var: _proc_find_author_books_descriptor;;
 
@@ -108,30 +86,60 @@ scp_program -> proc_find_similar_books
 
         -> .proc_find_similar_books_operator_find_genre_all_books
         (*
-           <- searchElStr5;;
+           <- searchSetStr3;;
 
-            -> rrel_1: rrel_fixed: rrel_scp_var: _book;;
-            -> rrel_2: rrel_assign: rrel_common: rrel_scp_var: _arc;;
-            -> rrel_3: rrel_assign: rrel_scp_var: _book_genre;;
-            -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _pos_arc;;
-            -> rrel_5: rrel_fixed:  rrel_scp_const: nrel_genre_work;;
+            -> rrel_1: rrel_assign: rrel_scp_var: _super_set;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
+            -> rrel_3: rrel_fixed: rrel_scp_var: _book;;
 
+            -> rrel_set_1: rrel_assign: rrel_scp_var: _book_super_set;;
 
-            => nrel_then: .proc_find_similar_books_operator_find_genres_1;;
+            => nrel_then: .proc_find_similar_books_operator_find_genres_01;;
             => nrel_else: .proc_find_similar_books_operator_print_end;;
         *);;
 
-	-> .proc_find_similar_books_operator_find_genres_1
+        -> .proc_find_similar_books_operator_find_genres_01
         (*
-            <- searchSetStr5;;
+           <- searchElStr3;;
 
-            -> rrel_1: rrel_assign: rrel_scp_var: _book_similar_genre;;
-            -> rrel_2: rrel_assign: rrel_common: rrel_scp_var: _arc;;
+            -> rrel_1: rrel_fixed: rrel_scp_var: _book_super_set;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _temp_elem_arc;;
+            -> rrel_3: rrel_assign: rrel_scp_var: _book_genre;;
+
+            => nrel_then: .proc_find_similar_books_operator_find_genres_02;;
+            => nrel_else: .proc_find_similar_books_operator_print_end;;
+        *);;
+
+        -> .proc_find_similar_books_operator_find_genres_02
+        (*
+            <- eraseEl;;
+
+           -> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _temp_elem_arc;;
+
+            => nrel_goto: .proc_find_similar_books_operator_find_genres_03;;
+        *);;
+
+         -> .proc_find_similar_books_operator_find_genres_03
+        (*
+           <- searchElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_const: genre;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
             -> rrel_3: rrel_fixed: rrel_scp_var: _book_genre;;
-            -> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _pos_arc;;
-            -> rrel_5: rrel_fixed:  rrel_scp_const: nrel_genre_work;;
 
-            -> rrel_set_1: rrel_assign: rrel_scp_var: _books_with_similar_genre;;
+            => nrel_then: .proc_find_similar_books_operator_find_genres_1;;
+            => nrel_else: .proc_find_similar_books_operator_find_genres_01;;
+        *);;
+
+	    -> .proc_find_similar_books_operator_find_genres_1
+        (*
+            <- searchSetStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _book_genre;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
+            -> rrel_3: rrel_assign: rrel_scp_var: _book_similar_genre;;
+
+            -> rrel_set_3: rrel_assign: rrel_scp_var: _books_with_similar_genre;;
 
             => nrel_goto: .proc_find_similar_books_operator_loop_to_find_book_in_specific_genre;;
         *);;
@@ -245,6 +253,14 @@ scp_program -> proc_find_similar_books
             <- printNl;;
 
             -> rrel_1: rrel_scp_const: [Конец обработки. Процедура поиска схожих книг];;
+
+            => nrel_goto: .proc_find_similar_books_operator_print_result;;
+        *);;
+         -> .proc_find_similar_books_operator_print_result
+        (*
+            <- printEl;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _similar_books;;
 
             => nrel_goto: .proc_find_similar_books_operator_return;;
         *);;

--- a/books_agents/search_agents/agent_of_recommending_books/agent_of_recommending_books.scsi
+++ b/books_agents/search_agents/agent_of_recommending_books/agent_of_recommending_books.scsi
@@ -1,0 +1,186 @@
+agent_of_recommending_books
+=> nrel_main_idtf:
+	[агентная scp-программа нахождения книжных рекомендаций] 
+		(* <- lang_ru;; *);
+	[agent scp-program of recommending books]
+		(* <- lang_en;; *);
+<- agent_scp_program;;
+
+scp_program -> agent_of_recommending_books
+(*
+
+	-> rrel_params: .agent_of_recommending_books_operator_params
+	(*
+		-> rrel_1: rrel_in: _event;;
+		-> rrel_2: rrel_in: _input_arc;;
+	*);;
+
+	-> rrel_operators: .agent_of_recommending_books_operators_set
+	(*
+		-> rrel_init: .agent_of_recommending_books_operator1
+		(*
+			<- searchElStr3;;
+
+			-> rrel_1: rrel_assign: rrel_scp_var: _temp;;
+			-> rrel_2: rrel_fixed: rrel_scp_var: _input_arc;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _quest;;
+
+			=> nrel_goto: .agent_of_recommending_books_operator2;;
+		*);;
+		
+
+		-> .agent_of_recommending_books_operator2
+		(*
+			<- searchElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: question_recommending_books;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _quest;;
+
+			=> nrel_then: .agent_of_recommending_books_operator3;;
+			=> nrel_else: .agent_of_recommending_books_operator_return;;
+		*);;
+
+		-> .agent_of_recommending_books_operator3
+		(*
+			<- printNl;;
+
+			-> rrel_1: rrel_scp_const: [Агент рекомендации книг];;
+
+			=> nrel_goto: .agent_of_recommending_books_operator4;;
+   		*);;
+
+		-> .agent_of_recommending_books_operator4
+		(*
+			<- searchElStr3;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
+			-> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc_to_author;;
+			-> rrel_3: rrel_assign: rrel_scp_var: _author;;
+
+			=> nrel_then: .agent_of_recommending_books_operator5_5;;
+			=> nrel_else: .agent_of_recommending_books_operator_return;;
+		*);;
+		-> .agent_of_recommending_books_operator5_5
+		(*
+			<- genEl;;
+
+			-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _answer;;
+
+			=> nrel_goto: .agent_of_recommending_books_operator_gen_recommended;;
+		*);;
+
+        -> .agent_of_recommending_books_operator_gen_recommended
+		(*
+			<- genEl;;
+
+			-> rrel_1: rrel_assign: rrel_const: rrel_node: rrel_scp_var: _recommended_books;;
+
+			=> nrel_goto: .agent_of_recommending_books_operator_call_proc;;
+		*);;
+
+	-> .agent_of_recommending_books_operator_call_proc
+		(*
+			<- call;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: proc_recommend_books;;
+			-> rrel_2: rrel_fixed: rrel_scp_const: ...
+			(*
+					-> rrel_1: rrel_fixed: rrel_scp_var: _author;;
+					-> rrel_2: rrel_fixed: rrel_scp_var: _recommended_books;;
+			*);;
+			-> rrel_3: rrel_assign: rrel_scp_var: _agent_of_recommending_books_descriptor;;
+
+			=> nrel_goto: .agent_of_recommending_books_operator_wait_call;;
+		*);;
+
+		-> .agent_of_recommending_books_operator_wait_call
+		(*
+			<- waitReturn;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _agent_of_recommending_books_descriptor;;
+
+			=> nrel_goto: .agent_of_recommending_books_operator_check_recommended_books;;
+		*);;
+        
+        //Проверка: нашлись ли рекомендации
+        -> .agent_of_recommending_books_operator_check_recommended_books
+        (*
+             <- searchElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _recommended_books;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _belonging_arc;;
+            -> rrel_3: rrel_assign: rrel_scp_var: _similar_book_elem;;
+
+            => nrel_then: .agent_of_recommending_books_operator_add_to_answer_0;;
+            => nrel_else: .agent_of_recommending_books_operator_books_not_found;;
+        *);;
+
+        //Добавить сообщение о неудачном поиске в ответ
+        -> .agent_of_recommending_books_operator_books_not_found
+        (*
+             <- genElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _belonging_arc;;
+            -> rrel_3: rrel_fixed: rrel_scp_const: [Рекомендации не найдены];;
+
+            => nrel_goto: .agent_of_recommending_books_operator7;;
+        *);;
+
+    
+       -> .agent_of_recommending_books_operator_add_to_answer_0
+        (*
+             <- genElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _belonging_arc;;
+            -> rrel_3: rrel_fixed: rrel_scp_var: rrel_node: _recommended_books;;
+
+            => nrel_goto: .agent_of_recommending_books_operator_add_to_answer_01;;
+        *);;
+        
+
+        -> .agent_of_recommending_books_operator_add_to_answer_01	
+        (*
+             <- searchSetStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _recommended_books;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _book_arc;;
+            -> rrel_3: rrel_assign: rrel_scp_var: _recommended_book_el;;
+
+            -> rrel_set_2: rrel_fixed: rrel_scp_var: _answer;;
+            -> rrel_set_3: rrel_fixed: rrel_scp_var: _answer;;
+
+            => nrel_goto: .agent_of_recommending_books_operator_print_answer;;
+        *);;
+        
+        -> .agent_of_recommending_books_operator_print_answer
+        (*
+            <- printEl;;
+
+           -> rrel_1: rrel_fixed: rrel_scp_var: _answer;;
+
+            => nrel_goto: .agent_of_recommending_books_operator7;;
+        *);;
+ 
+
+		-> .agent_of_recommending_books_operator7
+		(*
+			<- genElStr5;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _quest;;
+			-> rrel_2: rrel_assign: rrel_const: rrel_common: rrel_const: rrel_scp_var: _arc;;
+			-> rrel_3: rrel_fixed: rrel_scp_var: _answer;;
+			-> rrel_4: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _arc2;;
+			-> rrel_5: rrel_fixed: rrel_scp_const: nrel_answer;;
+			
+			=> nrel_goto: .agent_of_recommending_books_operator_return;;
+		*);;
+	
+		-> .agent_of_recommending_books_operator_return
+		(*
+			<- return;;
+		*);;
+	*);;
+*);;

--- a/books_agents/search_agents/agent_of_recommending_books/lib_component_agent_of_recommending_books.scs
+++ b/books_agents/search_agents/agent_of_recommending_books/lib_component_agent_of_recommending_books.scs
@@ -1,0 +1,24 @@
+lib_component_agent_of_recommending_books
+=> nrel_main_idtf:
+	[Компонент библиотеки. sc-агент рекомендации книг]
+		(* <- lang_ru;; *);
+	[Library component. sc-agent of recommending books]
+		(* <- lang_en;; *);
+
+<- platform_independent_reusable_component_OSTIS; 
+<- atomic_reusable_component_OSTIS; 
+<- reusable_scp_agent;
+
+=> nrel_attendant_component: 
+	lib_component_ui_menu_for_recommending_books; 
+
+-> rrel_key_sc_element: 
+	.platform_independent_realization_of_sc_agent_of_recommending_books;;
+
+question_recommending_books
+<- sc_node_not_relation;
+=> nrel_main_idtf:
+	[действие. рекомендовать книги]
+	(* <- lang_ru;; *);
+	[action. to recommend books]
+	(* <- lang_en;; *);;

--- a/books_agents/search_agents/agent_of_recommending_books/lib_component_ui_menu_for_recommending_books.scs
+++ b/books_agents/search_agents/agent_of_recommending_books/lib_component_ui_menu_for_recommending_books.scs
@@ -1,0 +1,12 @@
+lib_component_ui_menu_for_recommending_books
+=> nrel_main_idtf:
+	[Компонент библиотеки. Команда пользовательского интерфейса для рекомендации книг]
+		(* <- lang_ru;; *);
+	[Library component. User interface command of recommending books]
+		(* <- lang_en;; *);
+
+<- platform_independent_reusable_component_OSTIS;
+<- atomic_reusable_component_OSTIS;
+<- reusable_knowledge_base_sc_model_component;;
+
+lib_component_ui_menu_for_recommending_books = [*^"file://ui_menu_file_for_recommending_books.scsi"*];; 

--- a/books_agents/search_agents/agent_of_recommending_books/proc_recommend_books.scs
+++ b/books_agents/search_agents/agent_of_recommending_books/proc_recommend_books.scs
@@ -1,0 +1,156 @@
+scp_program -> proc_recommend_books
+(*
+    -> rrel_params: ...
+    (*
+        -> rrel_1: rrel_in: _author;;
+        -> rrel_2: rrel_in: _recommended_books;;
+    *);;
+
+    -> rrel_operators: ...
+    (*
+    	
+        -> rrel_init: .proc_recommend_books_operator_print_start
+        (*
+            <- printNl;;
+
+            -> rrel_1: rrel_scp_const: [Начало. Процедура нахождения книжных рекомендаций];;
+
+            => nrel_goto: .proc_recommend_books_operator_find_book_author_gen;;
+        *);;
+
+        -> .proc_recommend_books_operator_find_book_author_gen
+        (*
+            <- genEl;;
+
+            -> rrel_1: rrel_assign: rrel_scp_var: rrel_node: rrel_const: _author_books;;
+
+            => nrel_goto: .proc_recommend_books_operator_find_author_all_books;;
+        *);;
+
+
+		-> .proc_recommend_books_operator_find_author_all_books
+		(*
+			<- call;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: proc_find_books_of_author;;
+			-> rrel_2: rrel_fixed: rrel_scp_const: ...
+			(*
+					-> rrel_1: rrel_fixed: rrel_scp_var: _author;;
+					-> rrel_2: rrel_fixed: rrel_scp_var: _author_books;;
+			*);;
+			-> rrel_3: rrel_assign: rrel_scp_var: _proc_find_author_books_descriptor;;
+
+			=> nrel_goto: .proc_recommend_books_operator_find_author_all_books_wait;;
+		*);;
+
+		-> .proc_recommend_books_operator_find_author_all_books_wait
+		(*
+			<- waitReturn;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _proc_find_author_books_descriptor;;
+
+			=> nrel_goto: .proc_recommend_books_operator_author_books_set;;
+		*);;
+
+        //Добавление всех книг автора в рекомендации
+
+
+        // Перебор найденных книг автора     
+
+        -> .proc_recommend_books_operator_author_books_set
+        (*
+            <- searchSetStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _author_books;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _temp_arc_book_in_authors;;
+            -> rrel_3: rrel_assign: rrel_scp_var: _book;;
+
+            -> rrel_set_3: rrel_fixed: rrel_scp_var: _recommended_books;;
+
+	        => nrel_then: .proc_recommend_books_operator_author_books_found;;
+
+            => nrel_else: .proc_recommend_books_operator_print_end;;
+        *);;
+
+         -> .proc_recommend_books_operator_author_books_found
+        (*
+            <- searchElStr3;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _author_books;;
+            -> rrel_2: rrel_assign: rrel_pos_const_perm: rrel_scp_var: _temp_arc_book_in_authors;;
+            -> rrel_3: rrel_assign: rrel_scp_var: _book;;
+
+	        => nrel_then: .proc_recommend_books_operator_remove_the_book_2;;
+
+            => nrel_else: .proc_recommend_books_operator_print_end;;
+        *);;
+
+
+
+        -> .proc_recommend_books_operator_remove_the_book_2
+        (*
+            <- eraseEl;;
+
+           -> rrel_1: rrel_fixed: rrel_erase: rrel_scp_var: _temp_arc_book_in_authors;;
+
+            => nrel_goto: .proc_recommend_books_operator_loop_to_find_similar_books;;
+        *);;
+
+         -> .proc_recommend_books_operator_loop_to_find_similar_books
+		(*
+			<- call;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_const: proc_find_similar_books;;
+			-> rrel_2: rrel_fixed: rrel_scp_const: ...
+			(*
+					-> rrel_1: rrel_fixed: rrel_scp_var: _book;;
+					-> rrel_2: rrel_fixed: rrel_scp_var: _author_books;;
+					-> rrel_3: rrel_fixed: rrel_scp_var: _recommended_books;;
+			*);;
+			-> rrel_3: rrel_assign: rrel_scp_var: _proc_find_similar_books_descriptor;;
+
+			=> nrel_goto: .proc_recommend_books_operator_find_author_all_books_wait;;
+		*);;
+
+		-> .proc_recommend_books_operator_find_author_all_books_wait
+		(*
+			<- waitReturn;;
+
+			-> rrel_1: rrel_fixed: rrel_scp_var: _proc_find_similar_books_descriptor;;
+
+			=> nrel_goto: .proc_recommend_books_operator_find_author_all_books_sync;;
+		*);;
+        -> .proc_recommend_books_operator_find_author_all_books_sync
+		(*
+			<- syncronize;;
+			=> nrel_goto: .proc_recommend_books_operator_author_books_found;;
+		*);;
+
+
+        
+///////////////////////////////////////////////////////////////////////////////////
+    //Формирование ответа
+
+        -> .proc_recommend_books_operator_print_end
+        (*
+            <- printNl;;
+
+            -> rrel_1: rrel_scp_const: [Конец обработки. Процедура поиска книжных рекомендаций];;
+
+            => nrel_goto: .proc_recommend_books_operator_print_result;;
+        *);;
+        -> .proc_recommend_books_operator_print_result
+        (*
+            <- printEl;;
+
+            -> rrel_1: rrel_fixed: rrel_scp_var: _recommended_books;;
+
+            => nrel_goto: .proc_recommend_books_operator_return;;
+        *);;
+        
+    	-> .proc_recommend_books_operator_return
+    	(*
+    		<- return;;
+    	*);;
+    *);;
+*);;

--- a/books_agents/search_agents/agent_of_recommending_books/sc_agent_of_agent_of_recommending_books.scs
+++ b/books_agents/search_agents/agent_of_recommending_books/sc_agent_of_agent_of_recommending_books.scs
@@ -1,0 +1,50 @@
+sc_agent_of_recommending_books
+=> nrel_main_idtf:
+	[sc-агент рекомендации книг] 
+		(* <- lang_ru;; *);
+	[sc-agent of finding similar books] 
+		(* <- lang_en;; *);
+
+<- abstract_sc_agent;
+
+=> nrel_primary_initiation_condition: 
+		(sc_event_add_output_arc => question_initiated);
+
+=> nrel_initiation_condition_and_result: 
+		(..sc_agent_of_recommending_books_initiation => ..sc_agent_of_recommending_books_result);
+
+<= nrel_sc_agent_key_sc_elements:
+	{
+	question_initiated;
+	question;
+	question_recommending_books
+	};
+
+=> nrel_inclusion: 
+	.platform_independent_realization_of_sc_agent_of_recommending_books
+	(*
+	<- platform_independent_abstract_sc_agent;;
+	<= nrel_sc_agent_program: 
+		{
+		agent_of_recommending_books;
+		proc_recommend_books
+		};;
+	-> sc_agent_of_recommending_books_scp (* <- active_sc_agent;; *);;
+	*);;
+
+..sc_agent_of_recommending_books_initiation
+= [*
+	question_recommending_books _-> .._question;;
+	question_initiated _-> .._question;;
+	question _-> .._question;;
+	.._question _-> .._parameter;;
+*];;
+
+..sc_agent_of_recommending_books_result
+= [*
+	question_recommending_books _-> .._question;;
+	question_finished _-> .._question;;
+	question _-> .._question;;
+	.._question _=> nrel_answer:: .._answer;;
+	.._question _-> .._parameter;;
+*];;

--- a/books_agents/search_agents/agent_of_recommending_books/sc_text_of_agent_of_recommending_books.scs
+++ b/books_agents/search_agents/agent_of_recommending_books/sc_text_of_agent_of_recommending_books.scs
@@ -1,0 +1,13 @@
+sc_text_of_agent_of_recommending_books
+-> rrel_key_sc_element:
+	agent_of_recommending_books;
+
+<- scp_program_sc_text;
+
+=> nrel_main_idtf: 
+	[sc-текст агентной scp-программы книжных рекомендаций] 
+	(* <- lang_ru;; *);
+	[sc-text scp-agent based program recommending books] 
+	(* <- lang_en;; *);;
+
+sc_text_of_agent_of_recommending_books = [*^"file://agent_of_recommending_books.scsi"*];;

--- a/books_agents/search_agents/agent_of_recommending_books/ui_menu_file_for_recommending_books.scsi
+++ b/books_agents/search_agents/agent_of_recommending_books/ui_menu_file_for_recommending_books.scsi
@@ -1,0 +1,21 @@
+ui_menu_file_for_recommending_books
+	<- 	ui_user_command_class_atom; 
+		ui_user_command_class_view_kb;
+	=> nrel_main_idtf: 
+		[Рекомендовать книги]
+			(* <- lang_ru;; *);
+		[Recommend books]
+			(* <- lang_en;; *);
+	=> ui_nrel_command_template:
+		[*
+		question_recommending_books _-> ._question_recommending_books_instance
+			(*
+				_-> rrel_1:: ui_arg_1;;
+			*);;
+		._question_recommending_books_instance _<- question;;
+		*];
+	=> ui_nrel_command_lang_template: 
+		[Запрос книжных рекомендаций: $ui_arg_1] 
+			(* <- lang_ru;; *);
+		[Request to recommend books: $ui_arg_1]
+			(* <- lang_en;; *);;

--- a/books_kb/subject_domain_of_books/section_subject_domain_of_books/section_theory_of_literature/section_theory_of_literature.scsi
+++ b/books_kb/subject_domain_of_books/section_subject_domain_of_books/section_theory_of_literature/section_theory_of_literature.scsi
@@ -67,7 +67,7 @@ nrel_genre_work
     *);;
 
 genre_biography
-
+<- genre;
 <- sc_node_not_relation;
 
 => nrel_main_idtf:
@@ -169,7 +169,7 @@ futurism
         *);;
     *);;
 genre_article
-
+<- genre;
 <- sc_node_not_relation;
 
 => nrel_main_idtf:
@@ -210,6 +210,7 @@ genre_article
     *);;
 
 genre_dystopia
+<- genre;
 <- sc_node_not_relation;
 
 => nrel_main_idtf:
@@ -245,6 +246,7 @@ genre_dystopia
     *);;
 
 genre_feuilleton
+<- genre;
 <- sc_node_not_relation;
 
 => nrel_main_idtf:
@@ -267,6 +269,7 @@ genre_feuilleton
     *);;
 
 genre_miniature
+<- genre;
 <- sc_node_not_relation;
 
 => nrel_main_idtf:
@@ -293,6 +296,7 @@ genre_miniature
     *);;
 
 genre_speculative_fiction
+<- genre;
 => nrel_main_idtf:
             [фантастика] (* <- lang_ru;; *);;
 
@@ -508,6 +512,7 @@ censorship <- rrel_key_sc_element: Definition_censorship
 		*);;
 	*);;
 sc_node_not_relation -> genre_criminal_prose;;
+genre -> genre_criminal_prose;;
 
 genre_criminal_prose => nrel_main_idtf:
         [криминальная проза](*<-lang_ru;;*);;
@@ -531,6 +536,7 @@ genre_criminal_prose <- rrel_key_sc_element: Definition_genre_criminal_prose
 	*);;
 
 sc_node_not_relation -> genre_docudrama;;
+genre -> genre_docudrama;;
 
 genre_docudrama => nrel_main_idtf:
         [документальный проза](*<-lang_ru;;*);;
@@ -556,6 +562,7 @@ genre_docudrama <- rrel_key_sc_element: Definition_genre_docudrama
 	*);;
 
 sc_node_not_relation -> genre_fantasy;;
+genre -> genre_fantasy;;
 
 genre_fantasy => nrel_main_idtf:
         [фэнтези](*<-lang_ru;;*);;
@@ -580,6 +587,7 @@ genre_fantasy <- rrel_key_sc_element: Definition_genre_fantasy
 
 
 sc_node_not_relation -> genre_gotic;;
+genre -> genre_gotic;;
 
 genre_gotic => nrel_main_idtf:
         [готическая литература](*<-lang_ru;;*);;
@@ -604,6 +612,7 @@ genre_gotic <- rrel_key_sc_element: Definition_genre_gotic
 	*);;
 
 sc_node_not_relation -> genre_horror;;
+genre -> genre_horror;;
 
 genre_horror => nrel_main_idtf:
         [ужас](*<-lang_ru;;*);;
@@ -630,6 +639,7 @@ genre_horror <- rrel_key_sc_element: Definition_genre_horror
 
 
 sc_node_not_relation -> genre_military;;
+genre -> genre_military;;
 
 genre_military => nrel_main_idtf:
         [военная проза](*<-lang_ru;;*);;
@@ -654,6 +664,7 @@ genre_military <- rrel_key_sc_element: Definition_genre_military
 	*);;
 
 sc_node_not_relation -> genre_postapokalipsis;;
+genre -> genre_postapokalipsis;;
 
 genre_postapokalipsis => nrel_main_idtf:
         [постапокалипсис](*<-lang_ru;;*);;
@@ -678,6 +689,7 @@ genre_postapokalipsis <- rrel_key_sc_element: Definition_genre_postapokalipsis
 	*);;
 
 sc_node_not_relation -> genre_romantic_prose;;
+genre -> genre_romantic_prose;;
 
 genre_romantic_prose => nrel_main_idtf:
         [любовная проза](*<-lang_ru;;*);;
@@ -702,6 +714,7 @@ genre_romantic_prose <- rrel_key_sc_element: Definition_genre_romantic_prose
 	*);;
 
 sc_node_not_relation -> genre_science_fiction;;
+genre -> genre_science_fiction;;
 
 genre_science_fiction => nrel_main_idtf:
         [научная фантастика](*<-lang_ru;;*);;
@@ -726,6 +739,7 @@ genre_science_fiction <- rrel_key_sc_element: Definition_genre_science_fiction
 
 
 sc_node_not_relation -> genre_thriller;;
+genre -> genre_thriller;;
 
 genre_thriller => nrel_main_idtf:
         [триллер](*<-lang_ru;;*);;
@@ -1272,25 +1286,3 @@ nrel_circulation => nrel_definitional_domain:
     -> value;;
 	*);;
    		 *);;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/books_kb/temp-idnt.scs
+++ b/books_kb/temp-idnt.scs
@@ -1,190 +1,205 @@
 country_USA 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [США](*<-lang_ru;;*);;
 
 country_Germany 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Германия](*<-lang_ru;;*);;
 
 country_Brazil
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Бразилия](*<-lang_ru;;*);;
 
 country_Ireland 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Ирландия](*<-lang_ru;;*);;
 
 country_France
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Франция](*<-lang_ru;;*);;
 
 country_South_Africa 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Южная Африка](*<-lang_ru;;*);;
 
 country_Great_Britain
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Великобритания](*<-lang_ru;;*);;
 
 country_Columbia
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Колумбия](*<-lang_ru;;*);;
 
 country_Mexico
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Мексика](*<-lang_ru;;*);;
 
 country_Austria_Hungary
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Австро-Венгрия](*<-lang_ru;;*);;
 
 country_Greece
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Греция](*<-lang_ru;;*);;
 
 country_Ukraine
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Украина](*<-lang_ru;;*);;
 
 country_Japan
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Япония](*<-lang_ru;;*);;
 
 genre_epistle 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [эпистол](*<-lang_ru;;*);;
 
 
 lang_de
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Немецкий язык](*<-lang_ru;;*);;
 
 lang_fr
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Французский язык](*<-lang_ru;;*);;
 
 lang_por
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Португальский язык](*<-lang_ru;;*);;
 
 lang_sp
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Испанский язык](*<-lang_ru;;*);;
 
 lang_jp
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Японский язык](*<-lang_ru;;*);;
 
 lang_tr
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Турецкий язык](*<-lang_ru;;*);;
 
 lang_german 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Немецкий язык](*<-lang_ru;;*);;
 
 lang_french 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [Французский язык](*<-lang_ru;;*);;
 
 genre_essay 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [эссе](*<-lang_ru;;*);;
 
 genre_narration 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [рассказ](*<-lang_ru;;*);;
 
 genre_autobiography 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [автобиография](*<-lang_ru;;*);;
 
 genre_short_novel 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [повесть](*<-lang_ru;;*);;
 
 writer 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [писатель](*<-lang_ru;;*);;
 
 male 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [мужчина](*<-lang_ru;;*);;
 
 female 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [женщина](*<-lang_ru;;*);;
 
 person 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [человек](*<-lang_ru;;*);;
 
 video_sequence
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [кино](*<-lang_ru;;*);;
 
 nrel_place_of_birth 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [место рождения*](*<-lang_ru;;*);;
 
 nrel_place_of_death
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [место смерти*](*<-lang_ru;;*);;
 
 nrel_date_of_birth
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [дата рождения*](*<-lang_ru;;*);;
 
 nrel_date_of_death 
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [дата смерти*](*<-lang_ru;;*);;
 
 mouse
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [мышь](*<- lang_ru;;*);;
 
 
 
 poet
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
 => nrel_main_idtf: [поэт] (*<- lang_ru;;*);;
 
 genre_novel
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [роман] (*<- lang_ru;;*);;
 
 genre_fairy_tale
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [сказка] (*<- lang_ru;;*);;
 
 genre_prose
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [проза] (*<- lang_ru;;*);;
 
 genre_narrative
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [рассказ] (*<- lang_ru;;*);;
 
 play
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [пьеса] (*<- lang_ru;;*);;
 
 genre_tale
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [повесть] (*<- lang_ru;;*);;
 
 genre_historical_novel
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [исторический роман] (*<- lang_ru;;*);;
 
 poetry
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [поэзия] (*<- lang_ru;;*);;
 
 detective
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [детектив] (*<- lang_ru;;*);;
 
 short_story
-<- sc_node_norole_relation;
+<- sc_node_not_relation;
+<- genre;
 => nrel_main_idtf: [новелла] (*<- lang_ru;;*);;

--- a/books_ui/menu/ui_menu_na_books.scs
+++ b/books_ui/menu/ui_menu_na_books.scs
@@ -10,5 +10,6 @@ ui_menu_na_books
 	{
 		ui_menu_search_book_by_template;
 		ui_menu_search_book_by_characters;
-    ui_menu_file_for_finding_similar_books
+    	ui_menu_file_for_finding_similar_books;
+		ui_menu_file_for_recommending_books
 	};;


### PR DESCRIPTION
- Добавлен агент поиска рекомендаций (используется в компоненте интерфейса). В текущей реализации принимает на вход автора и выдает список рекомендованных книг (включает себя все книги автора + похожие, похожие ищутся с помощью процедуры **proc_find_similar_books.scs** из агента agent_of_finding_similar_books)
![image](https://user-images.githubusercontent.com/14928356/49696114-0c132100-fbb6-11e8-9426-fa7a9cb5c901.png)

Результат:
![image](https://user-images.githubusercontent.com/14928356/49696126-3369ee00-fbb6-11e8-8976-42f036b7692f.png)

- Рефакторинг агента поиска схожих книг
- Добавлена принадлежность жанров к классу genre, без этого агенты ничего не найдут