### PR TITLE
Спецификация агентов для модулей компонента поиска книг

### DIFF
--- a/books_agents/search_agents/agent_search_book_append_character/lib_component_agent_append_character.scs
+++ b/books_agents/search_agents/agent_search_book_append_character/lib_component_agent_append_character.scs
@@ -1,0 +1,35 @@
+lib_component_agent_append_character_to_pattern
+=> nrel_main_idtf:
+	[Компонент библиотеки. sc-агент добавления персонажа в шаблон поиска]
+		(* <- lang_ru;; *);
+
+<- library_of_platform_dependent_reusable_components; 
+<- library_of_atomic_reusable_components;
+
+/*
+=> nrel_attendant_component: 
+	lib_component_ui_menu_search_book_by_template; 
+*/
+
+-> rrel_key_sc_element: 
+	.c_realization_of_append_character_to_pattern;
+
+<- key_sc_element:
+	...
+	(*
+	<- explanation;;
+	<= nrel_sc_text_translation:
+		...
+		(*
+		-> rrel_example:
+			[Задачей sc-агента добавления персонажа в шаблон поиска является добавление в заданный шаблон поиска книги сведений об одном из её персонажей: его имени, пола, роли и др.];;
+		*);;
+	*);;
+
+question_append_character_to_pattern
+<- sc_node_not_relation;
+=> nrel_main_idtf:
+ 	[действие. добавить персонажа в шаблон поиска]
+		(* <- lang_ru;; *);
+	[action. append character to search pattern]
+		(* <- lang_en;;	*);;

--- a/books_agents/search_agents/agent_search_book_append_character/lib_component_agent_append_character.scs
+++ b/books_agents/search_agents/agent_search_book_append_character/lib_component_agent_append_character.scs
@@ -6,11 +6,6 @@ lib_component_agent_append_character_to_pattern
 <- library_of_platform_dependent_reusable_components; 
 <- library_of_atomic_reusable_components;
 
-/*
-=> nrel_attendant_component: 
-	lib_component_ui_menu_search_book_by_template; 
-*/
-
 -> rrel_key_sc_element: 
 	.c_realization_of_append_character_to_pattern;
 

--- a/books_agents/search_agents/agent_search_book_append_character/sc_agent_append_character.scs
+++ b/books_agents/search_agents/agent_search_book_append_character/sc_agent_append_character.scs
@@ -21,14 +21,11 @@ sc_agent_append_character_to_pattern
 	(*
 		<- platform_dependent_abstract_sc_agent;;
 
-		// TODO: fix github link
-		/*
 		<= nrel_sc_agent_program: 
 		{
-			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search/agents/books/search_book_character.cpp; syntax=cpp] (* => nrel_format: format_github_source_link;; *);
-			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search/agents/books/search_book_character.h; syntax=cpp] (* => nrel_format: format_github_source_link;; *)
+			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search-books/search_book_append_character.cpp; syntax=cpp] (* => nrel_format: format_github_source_link;; *);
+			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search-books/search_book_append_character.h; syntax=cpp] (* => nrel_format: format_github_source_link;; *)
 		};;
-		*/
 
 		-> sc_agent_append_character_to_pattern_agent_c
 			(* <- active_sc_agent;; *);;

--- a/books_agents/search_agents/agent_search_book_append_character/sc_agent_append_character.scs
+++ b/books_agents/search_agents/agent_search_book_append_character/sc_agent_append_character.scs
@@ -1,0 +1,52 @@
+sc_agent_append_character_to_pattern
+=> nrel_main_idtf:
+	[sc-агент добавления персонажа в шаблон поиска]
+		(* <- lang_ru;; *);
+	[sc-agent of appending character to search pattern]
+		(* <- lang_en;; *);
+
+<- abstract_sc_agent;
+=> nrel_primary_initiation_condition:
+	(sc_event_add_output_arc => question_initiated);
+=> nrel_initiation_condition_and_result:
+	(..sc_agent_append_character_to_pattern_initiation_condition => ..sc_agent_append_character_to_pattern_result);
+<= nrel_sc_agent_key_sc_elements: 
+	{
+		question_initiated;
+		question;
+		question_append_character_to_pattern
+	};
+=> nrel_inclusion: 
+	.c_realization_of_append_character_to_pattern
+	(*
+		<- platform_dependent_abstract_sc_agent;;
+
+		// TODO: fix github link
+		/*
+		<= nrel_sc_agent_program: 
+		{
+			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search/agents/books/search_book_character.cpp; syntax=cpp] (* => nrel_format: format_github_source_link;; *);
+			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search/agents/books/search_book_character.h; syntax=cpp] (* => nrel_format: format_github_source_link;; *)
+		};;
+		*/
+
+		-> sc_agent_append_character_to_pattern_agent_c
+			(* <- active_sc_agent;; *);;
+	*);;
+
+..sc_agent_append_character_to_pattern_initiation_condition
+= [*
+	question_append_character_to_pattern _-> .._question;;
+	question_initiated _-> .._question;;
+	question _-> .._question;;
+	.._question _-> .._parameter;;
+*];;
+
+..sc_agent_append_character_to_pattern_result
+= [*
+	question_append_character_to_pattern _-> .._question;;
+	question_finished _-> .._question;;
+	question _-> .._question;;
+	.._question _=> nrel_answer:: .._answer;;
+	.._question _-> .._parameter;;
+*];;

--- a/books_agents/search_agents/agent_search_book_by_general_info/lib_component_agent_append_general_info.scs
+++ b/books_agents/search_agents/agent_search_book_by_general_info/lib_component_agent_append_general_info.scs
@@ -1,0 +1,35 @@
+lib_component_agent_append_general_info_to_pattern
+=> nrel_main_idtf:
+	[Компонент библиотеки. sc-агент добавления общей информации в шаблон поиска]
+		(* <- lang_ru;; *);
+
+<- library_of_platform_dependent_reusable_components; 
+<- library_of_atomic_reusable_components;
+
+/*
+=> nrel_attendant_component: 
+	lib_component_ui_menu_search_book_by_template; 
+*/
+
+-> rrel_key_sc_element: 
+	.c_realization_of_append_general_info_to_pattern;
+
+<- key_sc_element:
+	...
+	(*
+	<- explanation;;
+	<= nrel_sc_text_translation:
+		...
+		(*
+		-> rrel_example:
+			[Задачей sc-агента добавления общей информации в шаблон поиска является добавление в заданный шаблон поиска книги общей информации о книге: имени автора, языка, жанра и др.];;
+		*);;
+	*);;
+
+question_append_general_info_to_pattern
+<- sc_node_not_relation;
+=> nrel_main_idtf:
+ 	[действие. добавить общую информацию в шаблон поиска]
+		(* <- lang_ru;; *);
+	[action. append general info to search pattern]
+		(* <- lang_en;;	*);;

--- a/books_agents/search_agents/agent_search_book_by_general_info/lib_component_agent_append_general_info.scs
+++ b/books_agents/search_agents/agent_search_book_by_general_info/lib_component_agent_append_general_info.scs
@@ -6,11 +6,6 @@ lib_component_agent_append_general_info_to_pattern
 <- library_of_platform_dependent_reusable_components; 
 <- library_of_atomic_reusable_components;
 
-/*
-=> nrel_attendant_component: 
-	lib_component_ui_menu_search_book_by_template; 
-*/
-
 -> rrel_key_sc_element: 
 	.c_realization_of_append_general_info_to_pattern;
 

--- a/books_agents/search_agents/agent_search_book_by_general_info/sc_agent_append_general_info.scs
+++ b/books_agents/search_agents/agent_search_book_by_general_info/sc_agent_append_general_info.scs
@@ -1,0 +1,49 @@
+sc_agent_append_general_info_to_pattern
+=> nrel_main_idtf:
+	[sc-агент добавления общей информации в шаблон поиска]
+		(* <- lang_ru;; *);
+	[sc-agent of appending general info to search pattern]
+		(* <- lang_en;; *);
+
+<- abstract_sc_agent;
+=> nrel_primary_initiation_condition:
+	(sc_event_add_output_arc => question_initiated);
+=> nrel_initiation_condition_and_result:
+	(..sc_agent_append_general_info_to_pattern_initiation_condition => ..sc_agent_append_general_info_to_pattern_result);
+<= nrel_sc_agent_key_sc_elements: 
+	{
+		question_initiated;
+		question;
+		question_append_general_info_to_pattern
+	};
+=> nrel_inclusion: 
+	.c_realization_of_append_general_info_to_pattern
+	(*
+		<- platform_dependent_abstract_sc_agent;;
+
+		<= nrel_sc_agent_program: 
+		{
+			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search/agents/books/search_book_general_info.cpp; syntax=cpp] (* => nrel_format: format_github_source_link;; *);
+			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search/agents/books/search_book_general_info.h; syntax=cpp] (* => nrel_format: format_github_source_link;; *)
+		};;
+
+		-> sc_agent_append_general_info_to_pattern_agent_c
+			(* <- active_sc_agent;; *);;
+	*);;
+
+..sc_agent_append_general_info_to_pattern_initiation_condition
+= [*
+	question_append_general_info_to_pattern _-> .._question;;
+	question_initiated _-> .._question;;
+	question _-> .._question;;
+	.._question _-> .._parameter;;
+*];;
+
+..sc_agent_append_general_info_to_pattern_result
+= [*
+	question_append_general_info_to_pattern _-> .._question;;
+	question_finished _-> .._question;;
+	question _-> .._question;;
+	.._question _=> nrel_answer:: .._answer;;
+	.._question _-> .._parameter;;
+*];;

--- a/books_agents/search_agents/agent_search_book_by_general_info/sc_agent_append_general_info.scs
+++ b/books_agents/search_agents/agent_search_book_by_general_info/sc_agent_append_general_info.scs
@@ -23,8 +23,8 @@ sc_agent_append_general_info_to_pattern
 
 		<= nrel_sc_agent_program: 
 		{
-			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search/agents/books/search_book_general_info.cpp; syntax=cpp] (* => nrel_format: format_github_source_link;; *);
-			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search/agents/books/search_book_general_info.h; syntax=cpp] (* => nrel_format: format_github_source_link;; *)
+			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search-books/search_book_general_info.cpp; syntax=cpp] (* => nrel_format: format_github_source_link;; *);
+			[owner=ostis-books; repo=sc-machine; path= sc-kpm/search-books/search_book_general_info.h; syntax=cpp] (* => nrel_format: format_github_source_link;; *)
 		};;
 
 		-> sc_agent_append_general_info_to_pattern_agent_c


### PR DESCRIPTION
Добавлены **файлы спецификации агентов** для двух модулей универсального компонента поиска книг:
- агент модуля поиска *по общим сведениям*;
- агент модуля поиска *по персонажам*.